### PR TITLE
Call trackScrolling when need to layout update

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -324,6 +324,10 @@ public extension PanModalPresentationController {
      pan modal presentable value changes after the initial presentation
      */
     func setNeedsLayoutUpdate() {
+        
+        if let scrollView = presentable?.panScrollable {
+            trackScrolling(scrollView)
+        }
         configureViewLayout()
         adjustPresentedViewFrame()
         observe(scrollView: presentable?.panScrollable)
@@ -813,7 +817,7 @@ private extension PanModalPresentationController {
     }
 
     /**
-     As the user scrolls, track & save the scroll view y offset.
+     As the user scrolls or screen transition, track & save the scroll view y offset.
      This helps halt scrolling when we want to hold the scroll view in place.
      */
     func trackScrolling(_ scrollView: UIScrollView) {


### PR DESCRIPTION
###  Summary

The ["scrollViewYOffset"](https://github.com/awa/PanModal/blob/cd35e4af4ffdb9c88ff0d6b3c5e3189cebcd148f/PanModal/Controller/PanModalPresentationController.swift#L83) can be different for each screen, so it has to be updated when the layout needs to be updated.

So I modified it to call the trackScrolling method in the setNeedsLayoutUpdate method.

I have confirmed that the scrollViewYOffset tracks correctly even if the scrollViewYOffset changes due to screen transitions.


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
